### PR TITLE
Better mobile integration (allows text input)

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -81,6 +81,13 @@ end
 local function grabKeyboardFocus(id)
 	if isActive(id) then
 		keyboardFocus = id
+		if love.system.getOS() == "Android" or love.system.getOS() == "iOS" then
+			if id == NONE then
+				love.keyboard.setTextInput( false )
+			else
+				love.keyboard.setTextInput( true )
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Before the virtual keyboard would not show up when a text field was active, now objects attempting to grabKeyboardInput will also pull up the virtual keyboard if on mobile.

This has been tested on LOVE stable OSX as well as LOVE master iOS.

The one downside I see of this change is the possibility of the user of SUIT to be using love.keyboard.setTextInput(), however I'm not sure why they would be.