### PR TITLE
Add more options to override theme properties

### DIFF
--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -166,6 +166,9 @@ Common Options
 ``color``
    A table to overwrite the color. Undefined colors default to the theme colors.
 
+``cornerRadius``
+  The corner radius for boxes. Overwrites the theme corner radius.
+
 ``draw``
    A function to replace the drawing function. Refer to :doc:`themes` for more information about the function signatures.
 

--- a/theme.lua
+++ b/theme.lua
@@ -20,8 +20,10 @@ end
 
 function theme.drawBox(x,y,w,h, opt, colors)
 	local colors = colors or theme.getColorForState(opt)
+	local cornerRadius = opt.cornerRadius or theme.cornerRadius
+
 	love.graphics.setColor(colors.bg)
-	love.graphics.rectangle('fill', x,y, w,h, theme.cornerRadius)
+	love.graphics.rectangle('fill', x,y, w,h, cornerRadius)
 end
 
 function theme.getVerticalOffsetForAlign(valign, font, h)

--- a/theme.lua
+++ b/theme.lua
@@ -18,7 +18,8 @@ function theme.getColorForState(opt)
 	return (opt.color and opt.color[opt.state]) or theme.color[s]
 end
 
-function theme.drawBox(x,y,w,h, colors)
+function theme.drawBox(x,y,w,h, opt, colors)
+	local colors = colors or theme.getColorForState(opt)
 	love.graphics.setColor(colors.bg)
 	love.graphics.rectangle('fill', x,y, w,h, theme.cornerRadius)
 end
@@ -45,7 +46,7 @@ end
 function theme.Button(text, opt, x,y,w,h)
 	local c = theme.getColorForState(opt)
 
-	theme.drawBox(x,y,w,h, c)
+	theme.drawBox(x,y,w,h, opt)
 	love.graphics.setColor(c.fg)
 	love.graphics.setFont(opt.font)
 
@@ -57,7 +58,7 @@ function theme.Checkbox(chk, opt, x,y,w,h)
 	local c = theme.getColorForState(opt)
 	local th = opt.font:getHeight()
 
-	theme.drawBox(x+h/10,y+h/10,h*.8,h*.8, c)
+	theme.drawBox(x+h/10,y+h/10,h*.8,h*.8, opt)
 	love.graphics.setColor(c.fg)
 	if chk.checked then
 		love.graphics.setLineStyle('smooth')
@@ -85,8 +86,8 @@ function theme.Slider(fraction, opt, x,y,w,h)
 	end
 
 	local c = theme.getColorForState(opt)
-	theme.drawBox(x,y,w,h, c)
-	theme.drawBox(x,yb,wb,hb, {bg=c.fg})
+	theme.drawBox(x,y,w,h, opt)
+	theme.drawBox(x,yb,wb,hb, opt, {bg=c.fg})
 
 	if opt.state ~= nil and opt.state ~= "normal" then
 		love.graphics.setColor((opt.color and opt.color.active or {}).fg or theme.color.active.fg)
@@ -100,7 +101,7 @@ end
 
 function theme.Input(input, opt, x,y,w,h)
 	local utf8 = require 'utf8'
-	theme.drawBox(x,y,w,h, (opt.color and opt.color.normal) or theme.color.normal)
+	theme.drawBox(x,y,w,h, opt, (opt.color and opt.color.normal) or theme.color.normal)
 	x = x + 3
 	w = w - 6
 


### PR DESCRIPTION
Right now the only theme property besides the colors is the corner radius, so this allows the user to specify a per-widget corner radius that overrides the theme default.