### PR TITLE
 fix bug when input more than one character.

### DIFF
--- a/input.lua
+++ b/input.lua
@@ -58,7 +58,7 @@ return function(core, input, ...)
 		if char ~= "" then
 			local a,b = split(input.text, input.cursor)
 			input.text = table.concat{a, char, b}
-			input.cursor = input.cursor + 1
+			input.cursor = input.cursor + utf8.len(char)
 		end
 
 		-- text editing


### PR DESCRIPTION
As you can see, it olny move it cursor once when IME input more than one character , such as input "你好" at once.
![animation1](https://cloud.githubusercontent.com/assets/10757838/15707559/f0a6614e-282b-11e6-98c5-10201310a85a.gif)

and, change it to add "utf8(char)", The things is ok.
![animation2](https://cloud.githubusercontent.com/assets/10757838/15707586/0a9ba438-282c-11e6-8522-0cac44d03332.gif)
