### PR TITLE
Add Layout:up/down/left/right()

### DIFF
--- a/layout.lua
+++ b/layout.lua
@@ -35,8 +35,20 @@ function Layout:nextRow()
 	return self._x, self._y + self._h + self._pady
 end
 
+Layout.nextDown = Layout.nextRow
+
+function Layout:nextUp()
+	return self._x, self._y - self._h - self._pady
+end
+
 function Layout:nextCol()
 	return self._x + self._w + self._padx, self._y
+end
+
+Layout.nextRight = Layout.nextCol
+
+function Layout:nextLeft()
+	return self._x - self._w - self._padx, self._y
 end
 
 function Layout:push(x,y)
@@ -135,6 +147,22 @@ function Layout:row(w, h)
 	return x,y,w,h
 end
 
+Layout.down = Layout.row
+
+function Layout:up(w, h)
+	w,h = calc_width_height(self, w, h)
+	local x,y = self._x, self._y - (self._h or 0)
+
+	if not self._isFirstCell then
+		y = y - self._pady
+	end
+	self._isFirstCell = false
+
+	self._y, self._w, self._h = y, w, h
+
+	return x,y,w,h
+end
+
 function Layout:col(w, h)
 	w,h = calc_width_height(self, w, h)
 
@@ -150,6 +178,22 @@ function Layout:col(w, h)
 	return x,y,w,h
 end
 
+Layout.right = Layout.col
+
+function Layout:left(w, h)
+	w,h = calc_width_height(self, w, h)
+
+	local x,y = self._x - (self._w or 0), self._y
+
+	if not self._isFirstCell then
+		x = x - self._padx
+	end
+	self._isFirstCell = false
+
+	self._x, self._w, self._h = x, w, h
+
+	return x,y,w,h
+end
 
 local function layout_iterator(t, idx)
 	idx = (idx or 1) + 1
@@ -323,6 +367,10 @@ return setmetatable({
 	pop     = function(...) return instance:pop(...) end,
 	row     = function(...) return instance:row(...) end,
 	col     = function(...) return instance:col(...) end,
+	down    = function(...) return instance:down(...) end,
+	up      = function(...) return instance:up(...) end,
+	left    = function(...) return instance:left(...) end,
+	right   = function(...) return instance:right(...) end,
 	rows    = function(...) return instance:rows(...) end,
 	cols    = function(...) return instance:cols(...) end,
 }, {__call = function(_,...) return Layout.new(...) end})


### PR DESCRIPTION
up() places the next cell above the previous one, and left() places the
next cell to the left of the previous one. down() and right() are
aliases to row()/col(), for symmetry.

Also added are nextX() variants for function.

---

Here's the UI element in my game that inspired this:
![2016-08-09-012058_1280x720_scrot](https://cloud.githubusercontent.com/assets/137977/17505908/84b73918-5dd2-11e6-8d6c-52396a220619.png)

Since with the traditional row/col my UI layouts start at the top-right, I'd have to know in advance how many rows my widget would take to properly place it in the bottom left corner. Instead, I'd just eyeball it, and every time I add/remove a remove (like I did recently to add those two labels at the top), I'd have to eyeball it again.

Using this patch I can just start from the corner, and grow the layout upwards dynamically. 