### PR TITLE
Fix layout:pop() to actually pop off of the stack

### DIFF
--- a/layout.lua
+++ b/layout.lua
@@ -59,6 +59,7 @@ function Layout:pop()
 	self._w, self._h,
 	self._widths, self._heights = unpack(self._stack[#self._stack])
 	self._isFirstCell = false
+	self._stack[#self._stack] = nil
 
 	self._w, self._h = math.max(w, self._w or 0), math.max(h, self._h or 0)
 


### PR DESCRIPTION
test code:
```lua
local l = suit.layout
l:reset(100, 100)
l:padding(5, 5)

suit.Button("A", l:row(50, 50))
do l:push(l:row(50, 50))
	suit.Button("B", l:row(50, 50))
	do l:push(l:col(50, 50))
		suit.Button("1", l:row(50, 20))
		suit.Button("2", l:row(50, 20))
	l:pop() end
l:pop() end

suit.Button("C", l:row(50, 50))
```

expected behavior:
![2016-08-27-103220_207x244_scrot](https://cloud.githubusercontent.com/assets/137977/18028033/9674ff14-6c41-11e6-9241-9725d2d54bf8.png)

current behavior:
![2016-08-27-103315_159x211_scrot](https://cloud.githubusercontent.com/assets/137977/18028038/b8ebd162-6c41-11e6-9d49-97f19284380a.png)
