### PR TITLE
Fix up/left() cells

### DIFF
--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -67,6 +67,8 @@ according to the size of the popped layout.
 
 Used for nested row/column layouts.
 
+.. _layout-row:
+
 .. function:: row(w,h)
 
    :param mixed w,h: Cell width and height (optional).
@@ -91,14 +93,20 @@ Used to provide the last four arguments to a widget, e.g.::
     suit.Button("Options", suit.layout:row())
     suit.Button("Quit", suit.layout:row(nil, "median"))
 
+.. function:: down(w,h)
+
+An alias for :ref:`layout:row() <layout-row>`.
+
+.. _layout-col:
+
 .. function:: col(w,h)
 
    :param mixed w,h: Cell width and height (optional).
    :returns: Position and size of the cell: ``x,y,w,h``.
 
-Creates a new cell right to the current cell with width ``w`` and height ``h``.
-If either ``w`` or ``h`` is omitted, the value is set the last used value. Both
-``w`` and ``h`` can be a string, which takes the following meaning:
+Creates a new cell to the right of the current cell with width ``w`` and height
+``h``.  If either ``w`` or ``h`` is omitted, the value is set the last used
+value. Both ``w`` and ``h`` can be a string, which takes the following meaning:
 
 ``max``
    Maximum of all values since the last reset.
@@ -114,6 +122,59 @@ Used to provide the last four arguments to a widget, e.g.::
     suit.Button("OK", suit.layout:col(100,30))
     suit.Button("Cancel", suit.layout:col("max"))
 
+.. function:: right(w,h)
+
+An alias for :ref:`layout:col() <layout-col>`.
+
+.. function:: up(w,h)
+
+   :param mixed w,h: Cell width and height (optional).
+   :returns: Position and size of the cell: ``x,y,w,h``.
+
+Creates a new cell above the current cell with width ``w`` and height ``h``. If
+either ``w`` or ``h`` is omitted, the value is set the last used value. Both
+``w`` and ``h`` can be a string, which takes the following meaning:
+
+``max``
+   Maximum of all values since the last reset.
+
+``min``
+   Mimimum of all values since the last reset.
+
+``median``
+   Median of all values since the last reset.
+
+Be careful when mixing ``up()`` and :ref:`layout:row() <layout-row>`, as suit
+does no checking to make sure cells don't overlap. e.g.::
+
+    suit.Button("A", suit.layout:row(100,30))
+    suit.Button("B", suit.layout:row())
+    suit.Button("Also A", suit.layout:up())
+
+.. function:: left(w,h)
+
+   :param mixed w,h: Cell width and height (optional).
+   :returns: Position and size of the cell: ``x,y,w,h``.
+
+Creates a new cell to the left of the current cell with width ``w`` and height
+``h``. If either ``w`` or ``h`` is omitted, the value is set the last used
+value. Both ``w`` and ``h`` can be a string, which takes the following meaning:
+
+``max``
+   Maximum of all values since the last reset.
+
+``min``
+   Mimimum of all values since the last reset.
+
+``median``
+   Median of all values since the last reset.
+
+Be careful when mixing ``left()`` and :ref:`layout:col() <layout-col>`, as suit
+does no checking to make sure cells don't overlap. e.g.::
+
+    suit.Button("A", suit.layout:col(100,30))
+    suit.Button("B", suit.layout:col())
+    suit.Button("Also A", suit.layout:left())
 
 Precomputed Layouts
 -------------------

--- a/layout.lua
+++ b/layout.lua
@@ -37,19 +37,11 @@ end
 
 Layout.nextDown = Layout.nextRow
 
-function Layout:nextUp()
-	return self._x, self._y - self._h - self._pady
-end
-
 function Layout:nextCol()
 	return self._x + self._w + self._padx, self._y
 end
 
 Layout.nextRight = Layout.nextCol
-
-function Layout:nextLeft()
-	return self._x - self._w - self._padx, self._y
-end
 
 function Layout:push(x,y)
 	self._stack[#self._stack+1] = {

--- a/layout.lua
+++ b/layout.lua
@@ -152,7 +152,7 @@ Layout.down = Layout.row
 
 function Layout:up(w, h)
 	w,h = calc_width_height(self, w, h)
-	local x,y = self._x, self._y - (self._h or 0)
+	local x,y = self._x, self._y - (self._h and h or 0)
 
 	if not self._isFirstCell then
 		y = y - self._pady
@@ -184,7 +184,7 @@ Layout.right = Layout.col
 function Layout:left(w, h)
 	w,h = calc_width_height(self, w, h)
 
-	local x,y = self._x - (self._w or 0), self._y
+	local x,y = self._x - (self._w and w or 0), self._y
 
 	if not self._isFirstCell then
 		x = x - self._padx


### PR DESCRIPTION
This is a bug that's pretty obvious when you use more than one cell size but I forgot to test for that, sorry~

Also documented the functions I added, and removed nextUp/nextLeft because they couldn't be determined without width/height info

test code

```
    suit.layout:reset(400, 400)
    suit.Button("A", suit.layout:right(100, 100))
    suit.Button("B", suit.layout:up(150, 50))
    suit.Button("C", suit.layout:left(75, 75))
    suit.Button("D", suit.layout:up(200, 25))
```

expected behavior
![2016-10-04 17_49_19-untitled](https://cloud.githubusercontent.com/assets/137977/19097643/1be51c2e-8a5b-11e6-9d6e-6a65c1a438ff.png)
current behavior
![2016-10-04 17_50_16-untitled](https://cloud.githubusercontent.com/assets/137977/19097642/1be35c04-8a5b-11e6-90b5-35d26dad64f8.png)
