### PR TITLE
Updates default theme to be Love 11.0 compatible.

### DIFF
--- a/theme.lua
+++ b/theme.lua
@@ -2,13 +2,24 @@
 
 local BASE = (...):match('(.-)[^%.]+$')
 
+local love = require 'love'
 local theme = {}
 theme.cornerRadius = 4
 
+local divisor = love.getVersion() < 11 and 1 or 255
 theme.color = {
-	normal   = {bg = { 0.25, 0.25, 0.25}, fg = {0.73,0.73,0.73}},
-	hovered  = {bg = { 0.19,0.6,0.73}, fg = {1,1,1}},
-	active   = {bg = {1,0.6,  0}, fg = {1,1,1}}
+	normal   = {
+		bg = { 66 / divisor, 66 / divisor, 66 / divisor},
+		fg = {188 / divisor, 188 / divisor, 188 / divisor}
+	},
+	hovered  = {
+		bg = { 50 / divisor, 153 / divisor, 187 / divisor},
+		fg = {255 / divisor, 255 / divisor, 255 / divisor}
+	},
+	active   = {
+		bg = {255 / divisor, 153 / divisor, 0 / divisor},
+		fg = {225 / divisor, 225 / divisor, 225 / divisor}
+	}
 }
 
 


### PR DESCRIPTION
-- In Love 11.0, they updated `love.graphics.setColor` to be in a
range from 0 to 1, rather than 0 to 255:
https://love2d.org/wiki/love.graphics.setColor.

As a result, the current SUIT default theme prints all white for all
text input fields. The fix is to divide all of our current color
settings by 255 if the major version is 11 or greater, and do nothing
otherwise.