### PR TITLE
Remove alpha value check from ImageButton

### DIFF
--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -39,8 +39,8 @@ Creates an image button widget at position ``(x,y)``.
 Unlike all other widgets, an ``ImageButton`` is not affected by the current
 theme.
 The argument ``normal`` defines the image of the normal state as well as the
-area of the widget: The button activates when the mouse is over a pixel with
-non-zero alpha value.
+area of the widget: The button activates when the mouse is over a pixel of the
+rectangular image area.
 You can provide additional ``hovered`` and ``active`` images, but the widget area
 is always computed from the ``normal`` image.
 

--- a/imagebutton.lua
+++ b/imagebutton.lua
@@ -11,14 +11,11 @@ return function(core, normal, ...)
 	opt.id = opt.id or opt.normal
 
 	opt.state = core:registerMouseHit(opt.id, x,y, function(u,v)
-		local id = opt.normal:getData()
-		assert(id:typeOf("ImageData"), "Can only use uncompressed images")
 		u, v = math.floor(u+.5), math.floor(v+.5)
 		if u < 0 or u >= opt.normal:getWidth() or v < 0 or v >= opt.normal:getHeight() then
 			return false
 		end
-		local _,_,_,a = id:getPixel(u,v)
-		return a > 0
+		return true
 	end)
 
 	local img = opt.normal


### PR DESCRIPTION
With LOVE 11.0 it is no longer possible to retrieve an ImageData from
an Image and thus there is no posibility to retrieve the alpha value
of a single pixel.
Another solution would be to additionally supply an ImageData
to the ImageButton in order to be able to retrieve the alpha values.