### PR TITLE
fix: set hovered, active properly

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -38,7 +38,7 @@ end
 
 -- gui state
 function suit:setHovered(id)
-	return self.hovered ~= id
+	self.hovered = id
 end
 
 function suit:anyHovered()
@@ -54,7 +54,7 @@ function suit:wasHovered(id)
 end
 
 function suit:setActive(id)
-	return self.active ~= nil
+	self.active = id
 end
 
 function suit:anyActive()


### PR DESCRIPTION
These were not implemented correctly. Works now as long as you set them
before creating the widgets in update(), something like:

``` lua
local suit = require('suit')

function love.update()
	suit.setHovered("Button A")

	suit.Button("Button A", 5, 5, 100, 20)
	suit.Button("Button B", 5, 30, 100, 20)
end

function love.draw()
  suit.draw()
end
```

Related: https://github.com/vrld/suit/issues/41