### PR TITLE
Fix assignments for active and hovered states

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -38,7 +38,9 @@ end
 
 -- gui state
 function suit:setHovered(id)
-	return self.hovered ~= id
+	local ischanged = self.hovered ~= id
+	self.hovered = id
+	return ischanged
 end
 
 function suit:anyHovered()
@@ -54,7 +56,9 @@ function suit:wasHovered(id)
 end
 
 function suit:setActive(id)
-	return self.active ~= nil
+	local ischanged = self.active ~= id
+	self.active = id
+	return ischanged
 end
 
 function suit:anyActive()


### PR DESCRIPTION
Seems assignments of setActive and setHovered were kinda wrong.

For my use-case this was problematic. I wanted to set hovered property programmatically for control input in menus. When using a gamepad or keyboard it's nice to see what control is currently hovered, so one can know how to navigate to previous or next item. 
